### PR TITLE
Flake build fix

### DIFF
--- a/build_helper/default.nix
+++ b/build_helper/default.nix
@@ -36,7 +36,7 @@
                 
                 export HOME="$out/bin/home"
                 mkdir -p "$out/bin"
-                "${deno}/bin/deno" compile --allow-all --quiet --output "$out/bin/nvs" "$src/build_helper/main.bundle.js"
+                DENO_DIR=.deno deno install --root "$out" --name nvs --allow-all "$src/build_helper/main.bundle.js"
                 rm -rf "$HOME"
             ''
         ];

--- a/default.nix
+++ b/default.nix
@@ -43,7 +43,7 @@
                 
                 export HOME="$out/bin/home"
                 mkdir -p "$out/bin"
-                "${deno}/bin/deno" compile --allow-all --quiet --output "$out/bin/nvs" "$src/build_helper/main.bundle.js"
+                DENO_DIR=.deno deno install --root "$out" --name nvs --allow-all "$src/build_helper/main.bundle.js"
                 rm -rf "$HOME"
             ''
         ];

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713596654,
-        "narHash": "sha256-LJbHQQ5aX1LVth2ST+Kkse/DRzgxlVhTL1rxthvyhZc=",
+        "lastModified": 1719468428,
+        "narHash": "sha256-vN5xJAZ4UGREEglh3lfbbkIj+MPEYMuqewMn4atZFaQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fd16bb6d3bcca96039b11aa52038fafeb6e4f4be",
+        "rev": "1e3deb3d8a86a870d925760db1a5adecc64d329d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,8 @@
                 nvs = (pkgs.callPackage
                     (builtins.import ./default.nix)
                     {
+                        inherit system;
+                        _pkgs = pkgs;
                     }
                 );
             in

--- a/readme.md
+++ b/readme.md
@@ -22,9 +22,9 @@ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix 
 Then install nvs:
 
 ```sh
-nix-env -i -f https://github.com/jeff-hykin/nix_version_search_cli/archive/423e829ee2f40e99be233de63f09d44dd39e9f67.tar.gz
+nix-env -i -f https://github.com/jeff-hykin/nix_version_search_cli/archive/9b1b2fb614ae381ad091b7563cd20a1c006dce6f.tar.gz
 # or, if you have flakes:
-nix profile install 'https://github.com/jeff-hykin/nix_version_search_cli/archive/423e829ee2f40e99be233de63f09d44dd39e9f67.tar.gz#nvs'
+nix profile install 'https://github.com/jeff-hykin/nix_version_search_cli/archive/9b1b2fb614ae381ad091b7563cd20a1c006dce6f.tar.gz#nvs'
 ```
 
 ## How to use


### PR DESCRIPTION
Fixes #6.

Switching from `deno compile` to `deno install` seems unfortunate, but it looks like working around the flake build sandbox would be pretty painful. Alternatively we could replace `builtins.import ./default.nix` with another derivation definition within `flake.nix`?